### PR TITLE
Remove player and opponent columns from games

### DIFF
--- a/priv/repo/migrations/20170703140447_remove_player_and_opponent_from_games.exs
+++ b/priv/repo/migrations/20170703140447_remove_player_and_opponent_from_games.exs
@@ -1,0 +1,10 @@
+defmodule CoverMyPingPong.Repo.Migrations.RemovePlayerAndOpponentFromGames do
+  use Ecto.Migration
+
+  def change do
+    alter table(:games) do
+      remove :player
+      remove :opponent
+    end
+  end
+end


### PR DESCRIPTION
Reason?
> Player and Opponent columns in the Game model are no longer used. Can remove them from the db table

Closes: #8 